### PR TITLE
Moved to type families, added unpack fields option and added list instances

### DIFF
--- a/src/Data/Strict/Class.hs
+++ b/src/Data/Strict/Class.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE TypeFamilies #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -20,9 +19,10 @@ module Data.Strict.Class (
   liftStrict
 ) where
 
-class IsStrict l s | l -> s, s -> l where
-  fromStrict :: s -> l
-  toStrict   :: l -> s
+class IsStrict s where
+  type Lazy s
+  fromStrict :: s -> Lazy s
+  toStrict   :: Lazy s -> s
 
-liftStrict :: IsStrict l s => (l -> l) -> (s -> s)
+liftStrict :: IsStrict s => (Lazy s -> Lazy s) -> (s -> s)
 liftStrict f = toStrict . f . fromStrict

--- a/src/Data/Strict/Either.hs
+++ b/src/Data/Strict/Either.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -40,7 +40,8 @@ import Data.Strict.Class
 data Either a b = Left !a | Right !b
   deriving (Eq, Ord, Read, Show, Functor, Traversable, Foldable, Generic, Generic1, Data, Typeable)
 
-instance IsStrict (L.Either a b) (Either a b) where
+instance IsStrict (Either a b) where
+  type Lazy (Either a b) = (L.Either a b)
   toStrict   (L.Left x)  = Left x
   toStrict   (L.Right y) = Right y
   fromStrict (Left x)    = L.Left x

--- a/src/Data/Strict/List.hs
+++ b/src/Data/Strict/List.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE CPP #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -30,6 +31,7 @@ import GHC.Generics (Generic, Generic1)
 import Data.Data (Data, Typeable)
 import Data.Strict.Trustworthy
 import Data.Strict.Class
+import Data.Semigroup (Semigroup, (<>))
 
 infixr 5 :!
 
@@ -38,7 +40,7 @@ data List a = Nil | !a :! !(List a)
   deriving (Eq, Ord, Show, Read, Functor, Foldable, Traversable, Generic, Generic1, Data, Typeable)
 
 instance IsStrict (List a) where
-  type Lazy (List a) = [a] 
+  type Lazy (List a) = [a]
   toStrict   = foldr (:!) Nil
   fromStrict = foldr (:) []
 
@@ -46,3 +48,31 @@ instance IsList (List a) where
   type Item (List a) = a
   fromList = toStrict
   toList   = fromStrict
+
+instance Applicative List where
+  {-# INLINE pure #-}
+  pure x = x :! Nil
+  {-# INLINE (<*>) #-}
+  fl <*> xl = go fl where
+    go (f:!fs) = go' xl where
+      go' (x:!xs) = (f x) :! go' xs
+      go' Nil = go fs
+    go Nil = Nil
+
+#if MIN_VERSION_base(4,10,0)
+  {-# INLINE liftA2 #-}
+  liftA2 f xl yl = go xl where
+    go (x:!xs) = go' yl where
+      go' (y:!ys) = (f x y) :! go' ys
+      go' Nil = go xs
+    go Nil = Nil
+#endif
+
+instance Semigroup (List a) where
+  (<>) xl yl = go xl where
+    go (x:!xs) = x :! go xs
+    go Nil = yl
+
+instance Monoid (List a) where
+  mappend = (<>)
+  mempty = Nil

--- a/src/Data/Strict/List.hs
+++ b/src/Data/Strict/List.hs
@@ -37,7 +37,8 @@ infixr 5 :!
 data List a = Nil | !a :! !(List a)
   deriving (Eq, Ord, Show, Read, Functor, Foldable, Traversable, Generic, Generic1, Data, Typeable)
 
-instance IsStrict [a] (List a) where
+instance IsStrict (List a) where
+  type Lazy (List a) = [a] 
   toStrict   = foldr (:!) Nil
   fromStrict = foldr (:) []
 

--- a/src/Data/Strict/List/NonEmpty.hs
+++ b/src/Data/Strict/List/NonEmpty.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -39,7 +38,8 @@ infixr 5 :|
 data NonEmpty a = !a :| !(List a)
   deriving (Eq, Ord, Show, Read, Functor, Foldable, Traversable, Generic, Generic1, Data, Typeable)
 
-instance IsStrict (L.NonEmpty a) (NonEmpty a) where
+instance IsStrict (NonEmpty a) where
+  type Lazy (NonEmpty a) = L.NonEmpty a
   toStrict   (a L.:| as) = a   :| toStrict as
   fromStrict (a   :| as) = a L.:| fromStrict as
 

--- a/src/Data/Strict/Maybe.hs
+++ b/src/Data/Strict/Maybe.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -48,7 +48,8 @@ import Data.Strict.Class
 data Maybe a = Nothing | Just !a
   deriving (Eq, Ord, Show, Read, Functor, Foldable, Traversable, Generic, Generic1, Data, Typeable)
 
-instance IsStrict (L.Maybe a) (Maybe a) where
+instance IsStrict (Maybe a) where
+  type Lazy (Maybe a) = (L.Maybe a)
   toStrict   L.Nothing  = Nothing
   toStrict   (L.Just x) = Just x
   fromStrict Nothing    = L.Nothing

--- a/src/Data/Strict/Tuple.hs
+++ b/src/Data/Strict/Tuple.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -51,7 +51,8 @@ data Pair a b = !a :!: !b
 -- This gives a nicer syntax for the type but only works in GHC for now.
 type (:!:) = Pair
 
-instance IsStrict (a, b) (Pair a b) where
+instance IsStrict (Pair a b) where
+  type Lazy (Pair a b) = (a,b)
   toStrict   (a, b)    = a :!: b
   fromStrict (a :!: b) = (a, b)
 

--- a/strict-base.cabal
+++ b/strict-base.cabal
@@ -1,5 +1,5 @@
 Name:           strict-base
-Version:        0.4.0.0
+Version:        0.5.0.0
 Synopsis:       Strict versions of base data types.
 Category:       Data, System
 Description:    This package provides strict versions of some standard Haskell data

--- a/strict-base.cabal
+++ b/strict-base.cabal
@@ -19,7 +19,7 @@ source-repository head
   location: https://github.com/minad/strict-base
 
 library
-  ghc-options:       -Wall
+  ghc-options:       -Wall -funbox-strict-fields
   default-language:  Haskell2010
   hs-source-dirs:    src
   build-depends:     base >= 4.8 && < 5.0


### PR DESCRIPTION
I've made the following changes:

1. Changed the definition of `IsStrict` so it's now a single parameter type class with a type family parameter, and no longer uses functional dependencies. This was done so that there wouldn't be orphan instances.
2. Added `-funbox-strict-fields` to GHC options in cabal. I suspect most users of a strict library will want this for efficiency reasons. 
3. Added `Applicative`, `Semigroup` and `Monoid` to strict lists. There are more that could be added, I've just added a few for my purposes.
4. Bumped the version number to 0.5.0.0, as the changes in part 1 are not backward compatible and will cause compile errors for code which either defines it's own `IsStrict` instances or uses `IsStrict` in a type definition.